### PR TITLE
Typo in README

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -6,7 +6,7 @@ Over a series of projects, you will build a single networked, multithreaded, and
 asynchronous Rust application. Creating this application, a [key-value
 database][kv], will provide opportunities to exercise the best of the crate
 ecosystem, a variety of concurrent data types, the world of async Rust,
-interesting langauge features, and important Rust tools. In between projects are
+interesting language features, and important Rust tools. In between projects are
 small lessons and exercises on the subjects necessary to complete the next
 project.
 


### PR DESCRIPTION
'langauge' replaced with 'language'